### PR TITLE
Add dependency on mime-types

### DIFF
--- a/ops_preflight.gemspec
+++ b/ops_preflight.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency('thor', '~> 0.19.1')
+  gem.add_runtime_dependency('mime-types', '>= 2.99', '< 4.0')
   gem.add_runtime_dependency('fog', '~> 1.10')
   gem.add_runtime_dependency('mina', '~> 0.3.0')
   gem.add_runtime_dependency('aws-sdk', '~> 2')


### PR DESCRIPTION
Fix error introduced by fog having a 'soft' dependency on `mime-types`
